### PR TITLE
Updating runner from Node.js v12 to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: Allow the schema specified in the json-file to be downloaded.
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Fixing #17 by upgrading the GitHub Action runner from Node.js v12 to Node.js v16.

This change is required as GitHub will soon deprecate support for Node.js v12 actions. See the linked issue for further details.